### PR TITLE
Add byte-order mark to docs/*/*.md file

### DIFF
--- a/docs/odata-data-aggregation-ext/odata-data-aggregation-ext.md
+++ b/docs/odata-data-aggregation-ext/odata-data-aggregation-ext.md
@@ -1,4 +1,4 @@
-
+﻿
 ![OASIS Logo](https://docs.oasis-open.org/templates/OASISLogo-v3.0.png)
 
 -------

--- a/lib/README.md
+++ b/lib/README.md
@@ -81,7 +81,7 @@ The [`pdf.js`](pdf.js) module uses an embedded browser ([`puppeteer`](https://gi
 
 The following scripts can be executed manually or as part of a GitHub Action:
 
-- [`npm run build`](build.js) runs the conversion and writes the Markdown output as well as the HTML output into the [`doc/*`](../doc/odata-data-aggregation-ext) folder.
+- [`npm run build`](build.js) runs the conversion and writes the Markdown output as well as the HTML output into the [`doc/*`](../doc/odata-data-aggregation-ext) folder. The Markdown file starts with a byte-order mark (`EF BB BF`) so that it is recognized as UTF-8 when loaded from github.io.
 - [`npm run pdf`](build-pdf.mjs) runs the PDF conversion and writes the PDF document into the [`doc/*`](../doc/odata-data-aggregation-ext) folder.
 - [`npm test`](../test) runs a test suite.
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -19,6 +19,7 @@ fs.readdirSync(__dirname + "/..", { withFileTypes: true }).forEach(function (
         __dirname + "/../docs/" + doc.name + "/" + doc.name + ".html"
       )
     );
+    md.write(Buffer.of(0xEF, 0xBB, 0xBF));
     new Number(doc.name)
       .build(
         new PassThrough()


### PR DESCRIPTION
By adding a byte-order mark to the generated Markdown files, they are displayed as UTF-8 when loaded from github.io.

A browser in a Windows environment displays step 8 in section 3.1.3 of https://oasis-tcs.github.io/odata-specs/odata-data-aggregation-ext/odata-data-aggregation-ext.md (the authoritative document!) wrongly as:
```
8. Let $B=Î³(v,p_2)$.
```

With the byte-order mark, it correctly displays:
```
8. Let $B=γ(v,p_2)$.
```