### PR TITLE
Smartly update PDF files

### DIFF
--- a/lib/pdf.js
+++ b/lib/pdf.js
@@ -1,14 +1,36 @@
 const puppeteer = require("puppeteer");
+const { exec } = require("child_process");
 const fs = require("fs");
 const url = require("url");
 
 module.exports = async function (name, _variant, meta, force) {
   if (!force) {
+    const stylesDir = `${__dirname}/../docs/${name}/styles`;
     const htmlFile = `${__dirname}/../docs/${name}/${name}.html`;
     const pdfFile = `${__dirname}/../docs/${name}/${name}.pdf`;
-    const htmlStat = fs.statSync(htmlFile, { throwIfNoEntry: false });
-    const pdfStat = fs.statSync(pdfFile, { throwIfNoEntry: false });
-    if (pdfStat === undefined || htmlStat?.mtime > pdfStat?.mtime) force = true;
+    const sources = `${htmlFile} ${stylesDir}`;
+
+    let sourcesChanged = await commitTime(sources);
+    let pdfChanged = await commitTime(pdfFile);
+
+    const sourceDiffs = await hasDiffs(sources);
+    if (sourceDiffs) {
+      const htmlStat = fs.statSync(htmlFile, { throwIfNoEntry: false });
+      if (htmlStat?.mtime > sourcesChanged) sourcesChanged = htmlStat?.mtime;
+      // get maximum modified timestamp of html and styles
+      fs.readdirSync(stylesDir, { withFileTypes: true }).forEach((doc) => {
+        const stat = fs.statSync(`${stylesDir}/${doc.name}`);
+        if (stat.mtime > sourcesChanged) sourcesChanged = stat.mtime;
+      });
+    }
+
+    const pdfDiffs = await hasDiffs(pdfFile);
+    if (pdfDiffs) {
+      const pdfStat = fs.statSync(pdfFile, { throwIfNoEntry: false });
+      if (pdfStat?.mtime > pdfChanged) pdfChanged = pdfStat?.mtime;
+    }
+
+    if (pdfChanged === undefined || sourcesChanged > pdfChanged) force = true;
   }
 
   if (force) {
@@ -41,3 +63,27 @@ module.exports = async function (name, _variant, meta, force) {
     return true;
   }
 };
+
+async function commitTime(filenames) {
+  const res = await git(["log -1 --format=%cI --", filenames]);
+  const len = res.stdout.length;
+  return len === 0 ? undefined : new Date(res.stdout.substring(0, len - 1));
+}
+
+async function hasDiffs(filenames) {
+  const res = await git(["diff --quiet", filenames]);
+  return res.code !== 0;
+}
+
+function git(args, cwd) {
+  return new Promise((resolve) => {
+    exec(`git ${args.join(" ")}`, { cwd }, (error, stdout, stderr) => {
+      resolve({
+        code: error && error.code ? error.code : 0,
+        error,
+        stdout,
+        stderr,
+      });
+    });
+  });
+}


### PR DESCRIPTION
Update PDF file if it is older than the HTML and CSS files
- use timestamps of the committed versions
- if there are uncommitted changes in the filesystem, use the filesystem timestamps 