### PR TITLE
Fetch full history so test for "PDF needs refreshing" succeeds

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,6 +12,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Build docs
         run: |
           npm ci
-          npm run build
+          npm run html
           git config user.name ${GITHUB_ACTOR}
           git config user.email ${PUSHER_EMAIL}
           git add docs/*

--- a/.github/workflows/pdf.yml
+++ b/.github/workflows/pdf.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
PDF generation checks whether one of the sources is newer than the PDF. This only works if checkout fetches the full git history.

- [x] fetch full history in build and pdf scripts
- [x] only build html and md in build script