### PR TITLE
Add slash if missing

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -17,39 +17,45 @@ var app = express()
     var docs = [];
     iterator(function (srcname, name, variant) {
       docs.push(
-        `<li><a href="${srcname}/?variant=${variant}">${name}</a></li>`
+        `<li><a href="${srcname}/?variant=${variant}">${name}</a></li>`,
       );
     });
     res.send(`<h1>Documents</h1><ul>${docs.join("")}</ul>`);
   })
-  .get("/:doc/", function (req, res, next) {
-    try {
-      var branch = execSync("git branch --show-current", {
-        cwd: __dirname,
-      }).toString();
-      if (branch) req.query["-T"] = branch;
-    } catch (e) {}
-    try {
-      var number = new Number(
-        __dirname + "/../" + req.params.doc,
-        req.query.variant
-      );
-      var meta = `${__dirname}/../${req.params.doc}/${
-        req.query.variant || "meta"
-      }.yaml`;
-      delete req.query.variant;
-      res.type("html");
-      var proc = pandoc({
-        "--metadata-file": meta,
-        ...req.query,
-      });
-      proc.stdout.pipe(res);
-      number.build(proc.stdin).catch((err) => {
-        console.error();
-        console.error(err.join("\n"));
-      });
-    } catch (err) {
-      next();
+  .get("/:doc", function (req, res, next) {
+    if (req.path.endsWith("/")) {
+      try {
+        var branch = execSync("git branch --show-current", {
+          cwd: __dirname,
+        }).toString();
+        if (branch) req.query["-T"] = branch;
+      } catch (e) {}
+      try {
+        var number = new Number(
+          __dirname + "/../" + req.params.doc,
+          req.query.variant,
+        );
+        var meta = `${__dirname}/../${req.params.doc}/${
+          req.query.variant || "meta"
+        }.yaml`;
+        delete req.query.variant;
+        res.type("html");
+        var proc = pandoc({
+          "--metadata-file": meta,
+          ...req.query,
+        });
+        proc.stdout.pipe(res);
+        number.build(proc.stdin).catch((err) => {
+          console.error();
+          console.error(err.join("\n"));
+        });
+      } catch (err) {
+        next();
+      }
+    } else {
+      var url = new URL("s://" + req.originalUrl);
+      url.pathname += "/";
+      res.redirect(url.href.substring(4));
     }
   });
 
@@ -57,7 +63,7 @@ iterator(function (srcname, name, variant) {
   app.use(`/${srcname}/styles`, express.static(`${__dirname}/../styles`));
   app.use(
     `/${srcname}/images`,
-    express.static(`${__dirname}/../${srcname}/images`)
+    express.static(`${__dirname}/../${srcname}/images`),
   );
 });
 


### PR DESCRIPTION
`app.get("/:doc/", ...)` is no different from `app.get("/:doc", ...)`. Both variants also serve requests like `/odata-csdl?variant=json`, but then the styles and images cannot be loaded.

This PR redirects such a request to `/odata-csdl/?variant=json`.