### PR TITLE
Example 39 applies to Term

### DIFF
--- a/docs/odata-csdl-json/odata-csdl-json.html
+++ b/docs/odata-csdl-json/odata-csdl-json.html
@@ -2183,12 +2183,13 @@ Allowed values: -1.234567e3, 1e-101, 9.999999e96, not allowed values: 1e-102 and
 <span id="cb40-3"><a href="#cb40-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;$Type&quot;</span><span class="fu">:</span> <span class="st">&quot;Core.Tag&quot;</span><span class="fu">,</span></span>
 <span id="cb40-4"><a href="#cb40-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;$DefaultValue&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span></span>
 <span id="cb40-5"><a href="#cb40-5" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;$AppliesTo&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
-<span id="cb40-6"><a href="#cb40-6" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;Property&quot;</span></span>
-<span id="cb40-7"><a href="#cb40-7" aria-hidden="true" tabindex="-1"></a>  <span class="ot">]</span><span class="fu">,</span></span>
-<span id="cb40-8"><a href="#cb40-8" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;@Core.Description&quot;</span><span class="fu">:</span> <span class="st">&quot;Properties and terms annotated with this term</span></span>
-<span id="cb40-9"><a href="#cb40-9" aria-hidden="true" tabindex="-1"></a><span class="st">MUST contain a valid URL&quot;</span><span class="fu">,</span></span>
-<span id="cb40-10"><a href="#cb40-10" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;@Core.RequiresType&quot;</span><span class="fu">:</span> <span class="st">&quot;Edm.String&quot;</span></span>
-<span id="cb40-11"><a href="#cb40-11" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<span id="cb40-6"><a href="#cb40-6" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;Property&quot;</span><span class="ot">,</span></span>
+<span id="cb40-7"><a href="#cb40-7" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;Term&quot;</span></span>
+<span id="cb40-8"><a href="#cb40-8" aria-hidden="true" tabindex="-1"></a>  <span class="ot">]</span><span class="fu">,</span></span>
+<span id="cb40-9"><a href="#cb40-9" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;@Core.Description&quot;</span><span class="fu">:</span> <span class="st">&quot;Properties and terms annotated with this term</span></span>
+<span id="cb40-10"><a href="#cb40-10" aria-hidden="true" tabindex="-1"></a><span class="st">MUST contain a valid URL&quot;</span><span class="fu">,</span></span>
+<span id="cb40-11"><a href="#cb40-11" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;@Core.RequiresType&quot;</span><span class="fu">:</span> <span class="st">&quot;Edm.String&quot;</span></span>
+<span id="cb40-12"><a href="#cb40-12" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 </div>
 <h2 id="142-annotation"><a name="Annotation" href="#Annotation">14.2 Annotation</a></h2>
 <p>An annotation applies a <a href="#Term">term</a> to a model element and defines how to calculate a value for the term application. Both term and model element MUST be in scope. Section 14.1.2 specifies which model elements MAY be annotated with a term.</p>

--- a/docs/odata-csdl-json/odata-csdl-json.md
+++ b/docs/odata-csdl-json/odata-csdl-json.md
@@ -3683,7 +3683,8 @@ are defined in [OData-VocCore](#ODataVocCore))
   "$Type": "Core.Tag",
   "$DefaultValue": true,
   "$AppliesTo": [
-    "Property"
+    "Property",
+    "Term"
   ],
   "@Core.Description": "Properties and terms annotated with this term
 MUST contain a valid URL",

--- a/odata-csdl/14 Vocabulary and Annotation.md
+++ b/odata-csdl/14 Vocabulary and Annotation.md
@@ -312,7 +312,8 @@ are defined in [OData-VocCore](#ODataVocCore))
   "$Type": "Core.Tag",
   "$DefaultValue": true,
   "$AppliesTo": [
-    "Property"
+    "Property",
+    "Term"
   ],
   "@Core.Description": "Properties and terms annotated with this term
 MUST contain a valid URL",


### PR DESCRIPTION
Example 39 in the OData-CSDL spec is about a term that applies to `Property` and `Term`. Unlike the XML version, however, the JSON version does not include `Term` in the `$AppliesTo`.