### PR TITLE
Analyse with puppeteer

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -96,6 +96,10 @@ The following scripts can be executed manually or as part of a GitHub Action:
   - a copy of the common [`styles`](../styles) folder
   - a copy of the document-specific `*/images` folder, if this exists.
 - [`npm run pdf`](build-pdf.mjs) runs the PDF conversion and writes the PDF document into the [`docs/*`](../docs) folder.
+- [`npm run select <CSS selector> [<XPath expression>]`](selector.mjs) selects parts of the generated HTML documents by executing a CSS selector and optionally an XPath expression relative to each match. For example, syntax errors in JSON code snippets can be detected with
+  ```sh
+  npm run select ".json .er" "self::*[.!='…']/text()"
+  ```
 - [`npm test`](../test) runs a test suite.
 
 ## A note on diagrams

--- a/lib/selector.mjs
+++ b/lib/selector.mjs
@@ -7,6 +7,7 @@ iterator(function (srcname, name, variant) {
 });
 var browser = await puppeteer.launch({ headless: "new" });
 for (var name of docs) {
+  var heading = undefined;
   console.group(name);
   var page = await browser.newPage();
   await page.goto(`${import.meta.dirname}/../docs/${name}/${name}.html`, {
@@ -20,15 +21,31 @@ for (var name of docs) {
             ? await elem.$$("xpath/" + process.argv[3])
             : [elem];
           return elems.map((elem) =>
-            elem.evaluate((e) =>
-              e.nodeType === Node.ELEMENT_NODE ? e.outerHTML : e.nodeValue,
-            ),
+            elem.evaluate(function (e) {
+              return {
+                heading: document.evaluate(
+                  "preceding::*[self::h1|self::h2|self::h3|self::h4|self::h5|self::h6][1]",
+                  e,
+                  () => {},
+                  XPathResult.FIRST_ORDERED_NODE_TYPE,
+                ).singleNodeValue.textContent,
+                match:
+                  e.nodeType === Node.ELEMENT_NODE ? e.outerHTML : e.nodeValue,
+              };
+            }),
           );
         }),
       )
     ).flat(),
-  ))
-    console.log(r);
+  )) {
+    if (r.heading !== heading) {
+      if (heading) console.groupEnd();
+      console.group(r.heading);
+      heading = r.heading;
+    }
+    console.log(r.match);
+  }
+  if (heading) console.groupEnd();
   console.groupEnd();
 }
 process.exit(0);

--- a/lib/selector.mjs
+++ b/lib/selector.mjs
@@ -6,6 +6,7 @@ iterator(function (srcname, name, variant) {
   docs.push(name);
 });
 var browser = await puppeteer.launch({ headless: "new" });
+var exit_code = 0;
 for (var name of docs) {
   var heading = undefined;
   console.group(name);
@@ -20,6 +21,7 @@ for (var name of docs) {
           var elems = process.argv[3]
             ? await elem.$$("xpath/" + process.argv[3])
             : [elem];
+          if (elems.length > 0) exit_code = 1;
           return elems.map((elem) =>
             elem.evaluate(function (e) {
               return {
@@ -48,4 +50,4 @@ for (var name of docs) {
   if (heading) console.groupEnd();
   console.groupEnd();
 }
-process.exit(0);
+process.exit(exit_code);

--- a/lib/selector.mjs
+++ b/lib/selector.mjs
@@ -1,0 +1,28 @@
+import puppeteer from "puppeteer";
+import iterator from "./iterator.js";
+
+var docs = [];
+iterator(function (srcname, name, variant) {
+  docs.push(name);
+});
+var browser = await puppeteer.launch({ headless: "new" });
+for (var name of docs) {
+  console.group(name);
+  var page = await browser.newPage();
+  await page.goto(`${import.meta.dirname}/../docs/${name}/${name}.html`, {
+    waitUntil: "networkidle2",
+  });
+  var elements = await page.$$(process.argv[2]);
+  for (var elem of elements) {
+    var elems = process.argv[3]
+      ? await elem.$$("xpath/" + process.argv[3])
+      : [elem];
+    for (elem of elems)
+      console.log(
+        await elem.evaluate((e) =>
+          e.nodeType === Node.ELEMENT_NODE ? e.outerHTML : e.nodeValue,
+        ),
+      );
+  }
+  console.groupEnd();
+}

--- a/lib/selector.mjs
+++ b/lib/selector.mjs
@@ -12,17 +12,23 @@ for (var name of docs) {
   await page.goto(`${import.meta.dirname}/../docs/${name}/${name}.html`, {
     waitUntil: "networkidle2",
   });
-  var elements = await page.$$(process.argv[2]);
-  for (var elem of elements) {
-    var elems = process.argv[3]
-      ? await elem.$$("xpath/" + process.argv[3])
-      : [elem];
-    for (elem of elems)
-      console.log(
-        await elem.evaluate((e) =>
-          e.nodeType === Node.ELEMENT_NODE ? e.outerHTML : e.nodeValue,
-        ),
-      );
-  }
+  for (var r of await Promise.all(
+    (
+      await Promise.all(
+        (await page.$$(process.argv[2])).map(async function (elem) {
+          var elems = process.argv[3]
+            ? await elem.$$("xpath/" + process.argv[3])
+            : [elem];
+          return elems.map((elem) =>
+            elem.evaluate((e) =>
+              e.nodeType === Node.ELEMENT_NODE ? e.outerHTML : e.nodeValue,
+            ),
+          );
+        }),
+      )
+    ).flat(),
+  ))
+    console.log(r);
   console.groupEnd();
 }
+process.exit(0);

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "node lib/build.js",
     "pdf": "node lib/build-pdf.js",
     "start": "node lib/server",
+    "select": "node lib/selector.mjs",
     "test": "c8 -r html -r text mocha",
     "clean-xxx": "node lib/clean.mjs odata-xxx/temp odata-xxx-v4.0"
   },


### PR DESCRIPTION
A tool that helps with the analysis of the generated HTML documents. For example, syntax errors in code snippets can be detected with
```
node lib/selector.mjs ".json .er" "self::*[.!='…' and not(starts-with(.,' '))]/text()"
```
The first argument is a CSS selector, the (optional) second is an XPath expression.