### PR TITLE
Bound actions and function overloads via container

### DIFF
--- a/docs/odata-csdl-json/odata-csdl-json.html
+++ b/docs/odata-csdl-json/odata-csdl-json.html
@@ -2276,6 +2276,16 @@ Allowed values: -1.234567e3, 1e-101, 9.999999e96, not allowed values: 1e-102 and
 <td><pre><code>MySchema.MyAction</code></pre></td>
 </tr>
 <tr class="odd">
+<td>bound <a href="#Action">Action</a> overload via container</td>
+<td>Navigation Property via container or Property via container, followed by bound Action overload</td>
+<td><pre><code>MySchema.MyEntityContainer/MyEntitySet</code> <br><code> /MyNavigationProperty</code> <br><code> /MySchema.MyAction(Collection(MySchema.MyBindingType))</code></pre></td>
+</tr>
+<tr class="even">
+<td>all bound <a href="#Action">Action</a> overloads with given binding type via container</td>
+<td>Navigation Property via container or Property via container, followed by all overloads of an Action</td>
+<td><pre><code>MySchema.MyEntityContainer/MyEntitySet</code> <br><code> /MyNavigationProperty</code> <br><code> /MySchema.MyAction</code></pre></td>
+</tr>
+<tr class="odd">
 <td><a href="#ActionImport">Action Import</a></td>
 <td>qualified name of entity container followed by a segment containing the action import name</td>
 <td><pre><code>MySchema.MyEntityContainer/MyActionImport</code></pre></td>
@@ -2324,6 +2334,16 @@ Allowed values: -1.234567e3, 1e-101, 9.999999e96, not allowed values: 1e-102 and
 <td>all overloads of a <a href="#Function">Function</a></td>
 <td>qualified name of function</td>
 <td><pre><code>MySchema.MyFunction</code></pre></td>
+</tr>
+<tr class="odd">
+<td>bound <a href="#Function">Function</a> overload via container</td>
+<td>Navigation Property via container or Property via container, followed by bound Function overload</td>
+<td><pre><code>MySchema.MyEntityContainer/MyEntitySet</code> <br><code> /MyComplexProperty</code> <br><code> /MySchema.MyFunction(MySchema.MyBindingType)</code></pre></td>
+</tr>
+<tr class="even">
+<td>all bound <a href="#Function">Function</a> overloads of given binding type via container</td>
+<td>Navigation Property via container or Property via container, followed by all overloads of a Function</td>
+<td><pre><code>MySchema.MyEntityContainer/MyEntitySet</code> <br><code> /MyComplexProperty</code> <br><code> /MySchema.MyFunction</code></pre></td>
 </tr>
 <tr class="odd">
 <td><a href="#FunctionImport">Function Import</a></td>
@@ -2389,6 +2409,8 @@ Allowed values: -1.234567e3, 1e-101, 9.999999e96, not allowed values: 1e-102 and
 </table>
 <p>All <a href="#QualifiedName">qualified names</a> used in a target path MUST be in scope.</p>
 <p>External targeting is possible for properties and navigation properties of singletons or entities in a particular entity set. These annotations override annotations on the properties or navigation properties targeted via the declaring structured type.</p>
+<p>External targeting is also possible for action and function overloads that are bound to properties or navigation properties of singletons or entities in a particular entity set. These annotations override annotations targeting the action or function overloads directly.</p>
+<p>Note “all bound Action or Function overloads of given binding type via container” references all overloads where the binding parameter is an instance or a collection of the given type.</p>
 <h2 id="143-constant-expression"><a name="ConstantExpression" href="#ConstantExpression">14.3 Constant Expression</a></h2>
 <p>Constant expressions allow assigning a constant value to an applied term.</p>
 <h3 id="1431-binary"><a name="Binary" href="#Binary">14.3.1 Binary</a></h3>

--- a/docs/odata-csdl-json/odata-csdl-json.md
+++ b/docs/odata-csdl-json/odata-csdl-json.md
@@ -3841,6 +3841,8 @@ Model element| Can be targeted with path expression (see also [section 14.4.1.1]
 -----|-----|-----
 [Action](#Action) overload| qualified name of action followed by parentheses containing the binding parameter type of a bound action overload to identify that bound overload, or by empty parentheses to identify the unbound overload| <pre>`MySchema.MyAction(MySchema.MyBindingType)` <br>`MySchema.MyAction(Collection(MySchema.BindingType))` <br>`MySchema.MyAction()`</pre>
 all overloads of an [Action](#Action)| qualified name of action| <pre>`MySchema.MyAction`</pre>
+bound [Action](#Action) overload via container| Navigation Property via container or Property via container, followed by bound Action overload| <pre>`MySchema.MyEntityContainer/MyEntitySet` <br>` /MyNavigationProperty` <br>` /MySchema.MyAction(Collection(MySchema.MyBindingType))`</pre>
+all bound [Action](#Action) overloads with given binding type via container| Navigation Property via container or Property via container, followed by all overloads of an Action| <pre>`MySchema.MyEntityContainer/MyEntitySet` <br>` /MyNavigationProperty` <br>` /MySchema.MyAction`</pre>
 [Action Import](#ActionImport)| qualified name of entity container followed by a segment containing the action import name| <pre>`MySchema.MyEntityContainer/MyActionImport`</pre>
 [Annotation](#Annotation) on a model element| path expression identifying the model element followed by a segment containing an at (`@`) prepended to the qualified name of a term, optionally suffixed with a hash (`#`) and the qualifier of an annotation| <pre>`MySchema.MyEntityType/@MyVocabulary.MyTerm` <br>`MySchema.MyEntityType/@MyVocabulary.MyTerm#MyQualifier`</pre>
 [Complex Type](#ComplexType)| qualified name of complex type| <pre>`MySchema.MyComplexType`</pre>
@@ -3851,6 +3853,8 @@ all overloads of an [Action](#Action)| qualified name of action| <pre>`MySchema.
 [Enumeration Type Member](#EnumerationTypeMember)| qualified name of enumeration type followed by a segment containing the name of a child element| <pre>`MySchema.MyEnumType/MyMember`</pre>
 [Function](#Function) overload| qualified name of function followed by parentheses containing the comma-separated list of the parameter types of a bound or unbound function overload in the order of their definition in the function overload| <pre>`MySchema.MyFunction(MySchema.MyBindingParamType,` <br>`  First.NonBinding.ParamType)` <br>`MySchema.MyFunction(First.NonBinding.ParamType,` <br>`  Second.NonBinding.ParamType)`</pre>
 all overloads of a [Function](#Function)| qualified name of function| <pre>`MySchema.MyFunction`</pre>
+bound [Function](#Function) overload via container| Navigation Property via container or Property via container, followed by bound Function overload| <pre>`MySchema.MyEntityContainer/MyEntitySet` <br>` /MyComplexProperty` <br>` /MySchema.MyFunction(MySchema.MyBindingType)`</pre>
+all bound [Function](#Function) overloads of given binding type via container| Navigation Property via container or Property via container, followed by all overloads of a Function| <pre>`MySchema.MyEntityContainer/MyEntitySet` <br>` /MyComplexProperty` <br>` /MySchema.MyFunction`</pre>
 [Function Import](#FunctionImport)| qualified name of entity container followed by a segment containing the function import name| <pre>`MySchema.MyEntityContainer/MyFunctionImport`
 [Navigation Property](#NavigationProperty) via container| qualified name of entity container followed by a segment containing a singleton or entity set name and zero or more segments containing the name of a structural or navigation property, or a type-cast or term-cast| <pre>`MySchema.MyEntityContainer/MyEntitySet` <br>`  /MyNavigationProperty` <br>`MySchema.MyEntityContainer/MyEntitySet` <br>`  /MySchema.MyEntityType/MyNavProperty` <br>`MySchema.MyEntityContainer/MyEntitySet` <br>`  /MyComplexProperty/MyNavProperty` <br>`MySchema.MyEntityContainer/MySingleton` <br>`  /MyComplexProperty/MyNavProperty`</pre>
 [Navigation Property](#NavigationProperty) via structured type| qualified name of structured type followed by zero or more segments containing the name of a structural or navigation property, or a type-cast or term-cast| <pre>`MySchema.MyEntityType/MyNavigationProperty` <br>`MySchema.MyComplexType/MyNavigationProperty`</pre>
@@ -3870,6 +3874,15 @@ External targeting is possible for properties and navigation
 properties of singletons or entities in a particular entity set. These
 annotations override annotations on the properties or navigation
 properties targeted via the declaring structured type.
+
+External targeting is also possible for action and function overloads that
+are bound to properties or navigation properties of singletons or entities in
+a particular entity set. These annotations override annotations targeting the
+action or function overloads directly.
+
+Note "all bound Action or Function overloads of given binding type via
+container" references all overloads where the binding parameter is an instance
+or a collection of the given type.
 
 ## <a name="ConstantExpression" href="#ConstantExpression">14.3 Constant Expression</a>
 

--- a/docs/odata-csdl-xml/odata-csdl-xml.html
+++ b/docs/odata-csdl-xml/odata-csdl-xml.html
@@ -2092,6 +2092,16 @@ Allowed values: -1.234567e3, 1e-101, 9.999999e96, not allowed values: 1e-102 and
 <td><pre><code>MySchema.MyAction</code></pre></td>
 </tr>
 <tr class="odd">
+<td>bound <a href="#Action">Action</a> overload via container</td>
+<td>Navigation Property via container or Property via container, followed by bound Action overload</td>
+<td><pre><code>MySchema.MyEntityContainer/MyEntitySet</code> <br><code> /MyNavigationProperty</code> <br><code> /MySchema.MyAction(Collection(MySchema.MyBindingType))</code></pre></td>
+</tr>
+<tr class="even">
+<td>all bound <a href="#Action">Action</a> overloads with given binding type via container</td>
+<td>Navigation Property via container or Property via container, followed by all overloads of an Action</td>
+<td><pre><code>MySchema.MyEntityContainer/MyEntitySet</code> <br><code> /MyNavigationProperty</code> <br><code> /MySchema.MyAction</code></pre></td>
+</tr>
+<tr class="odd">
 <td><a href="#ActionImport">Action Import</a></td>
 <td>qualified name of entity container followed by a segment containing the action import name</td>
 <td><pre><code>MySchema.MyEntityContainer/MyActionImport</code></pre></td>
@@ -2140,6 +2150,16 @@ Allowed values: -1.234567e3, 1e-101, 9.999999e96, not allowed values: 1e-102 and
 <td>all overloads of a <a href="#Function">Function</a></td>
 <td>qualified name of function</td>
 <td><pre><code>MySchema.MyFunction</code></pre></td>
+</tr>
+<tr class="odd">
+<td>bound <a href="#Function">Function</a> overload via container</td>
+<td>Navigation Property via container or Property via container, followed by bound Function overload</td>
+<td><pre><code>MySchema.MyEntityContainer/MyEntitySet</code> <br><code> /MyComplexProperty</code> <br><code> /MySchema.MyFunction(MySchema.MyBindingType)</code></pre></td>
+</tr>
+<tr class="even">
+<td>all bound <a href="#Function">Function</a> overloads of given binding type via container</td>
+<td>Navigation Property via container or Property via container, followed by all overloads of a Function</td>
+<td><pre><code>MySchema.MyEntityContainer/MyEntitySet</code> <br><code> /MyComplexProperty</code> <br><code> /MySchema.MyFunction</code></pre></td>
 </tr>
 <tr class="odd">
 <td><a href="#FunctionImport">Function Import</a></td>
@@ -2205,6 +2225,8 @@ Allowed values: -1.234567e3, 1e-101, 9.999999e96, not allowed values: 1e-102 and
 </table>
 <p>All <a href="#QualifiedName">qualified names</a> used in a target path MUST be in scope.</p>
 <p>External targeting is possible for properties and navigation properties of singletons or entities in a particular entity set. These annotations override annotations on the properties or navigation properties targeted via the declaring structured type.</p>
+<p>External targeting is also possible for action and function overloads that are bound to properties or navigation properties of singletons or entities in a particular entity set. These annotations override annotations targeting the action or function overloads directly.</p>
+<p>Note “all bound Action or Function overloads of given binding type via container” references all overloads where the binding parameter is an instance or a collection of the given type.</p>
 <h2 id="143-constant-expression"><a name="ConstantExpression" href="#ConstantExpression">14.3 Constant Expression</a></h2>
 <p>Constant expressions allow assigning a constant value to an applied term.</p>
 <h3 id="1431-binary"><a name="Binary" href="#Binary">14.3.1 Binary</a></h3>

--- a/docs/odata-csdl-xml/odata-csdl-xml.md
+++ b/docs/odata-csdl-xml/odata-csdl-xml.md
@@ -3654,6 +3654,8 @@ Model element| Can be targeted with path expression (see also [section 14.4.1.1]
 -----|-----|-----
 [Action](#Action) overload| qualified name of action followed by parentheses containing the binding parameter type of a bound action overload to identify that bound overload, or by empty parentheses to identify the unbound overload| <pre>`MySchema.MyAction(MySchema.MyBindingType)` <br>`MySchema.MyAction(Collection(MySchema.BindingType))` <br>`MySchema.MyAction()`</pre>
 all overloads of an [Action](#Action)| qualified name of action| <pre>`MySchema.MyAction`</pre>
+bound [Action](#Action) overload via container| Navigation Property via container or Property via container, followed by bound Action overload| <pre>`MySchema.MyEntityContainer/MyEntitySet` <br>` /MyNavigationProperty` <br>` /MySchema.MyAction(Collection(MySchema.MyBindingType))`</pre>
+all bound [Action](#Action) overloads with given binding type via container| Navigation Property via container or Property via container, followed by all overloads of an Action| <pre>`MySchema.MyEntityContainer/MyEntitySet` <br>` /MyNavigationProperty` <br>` /MySchema.MyAction`</pre>
 [Action Import](#ActionImport)| qualified name of entity container followed by a segment containing the action import name| <pre>`MySchema.MyEntityContainer/MyActionImport`</pre>
 [Annotation](#Annotation) on a model element| path expression identifying the model element followed by a segment containing an at (`@`) prepended to the qualified name of a term, optionally suffixed with a hash (`#`) and the qualifier of an annotation| <pre>`MySchema.MyEntityType/@MyVocabulary.MyTerm` <br>`MySchema.MyEntityType/@MyVocabulary.MyTerm#MyQualifier`</pre>
 [Complex Type](#ComplexType)| qualified name of complex type| <pre>`MySchema.MyComplexType`</pre>
@@ -3664,6 +3666,8 @@ all overloads of an [Action](#Action)| qualified name of action| <pre>`MySchema.
 [Enumeration Type Member](#EnumerationTypeMember)| qualified name of enumeration type followed by a segment containing the name of a child element| <pre>`MySchema.MyEnumType/MyMember`</pre>
 [Function](#Function) overload| qualified name of function followed by parentheses containing the comma-separated list of the parameter types of a bound or unbound function overload in the order of their definition in the function overload| <pre>`MySchema.MyFunction(MySchema.MyBindingParamType,` <br>`  First.NonBinding.ParamType)` <br>`MySchema.MyFunction(First.NonBinding.ParamType,` <br>`  Second.NonBinding.ParamType)`</pre>
 all overloads of a [Function](#Function)| qualified name of function| <pre>`MySchema.MyFunction`</pre>
+bound [Function](#Function) overload via container| Navigation Property via container or Property via container, followed by bound Function overload| <pre>`MySchema.MyEntityContainer/MyEntitySet` <br>` /MyComplexProperty` <br>` /MySchema.MyFunction(MySchema.MyBindingType)`</pre>
+all bound [Function](#Function) overloads of given binding type via container| Navigation Property via container or Property via container, followed by all overloads of a Function| <pre>`MySchema.MyEntityContainer/MyEntitySet` <br>` /MyComplexProperty` <br>` /MySchema.MyFunction`</pre>
 [Function Import](#FunctionImport)| qualified name of entity container followed by a segment containing the function import name| <pre>`MySchema.MyEntityContainer/MyFunctionImport`
 [Navigation Property](#NavigationProperty) via container| qualified name of entity container followed by a segment containing a singleton or entity set name and zero or more segments containing the name of a structural or navigation property, or a type-cast or term-cast| <pre>`MySchema.MyEntityContainer/MyEntitySet` <br>`  /MyNavigationProperty` <br>`MySchema.MyEntityContainer/MyEntitySet` <br>`  /MySchema.MyEntityType/MyNavProperty` <br>`MySchema.MyEntityContainer/MyEntitySet` <br>`  /MyComplexProperty/MyNavProperty` <br>`MySchema.MyEntityContainer/MySingleton` <br>`  /MyComplexProperty/MyNavProperty`</pre>
 [Navigation Property](#NavigationProperty) via structured type| qualified name of structured type followed by zero or more segments containing the name of a structural or navigation property, or a type-cast or term-cast| <pre>`MySchema.MyEntityType/MyNavigationProperty` <br>`MySchema.MyComplexType/MyNavigationProperty`</pre>
@@ -3683,6 +3687,15 @@ External targeting is possible for properties and navigation
 properties of singletons or entities in a particular entity set. These
 annotations override annotations on the properties or navigation
 properties targeted via the declaring structured type.
+
+External targeting is also possible for action and function overloads that
+are bound to properties or navigation properties of singletons or entities in
+a particular entity set. These annotations override annotations targeting the
+action or function overloads directly.
+
+Note "all bound Action or Function overloads of given binding type via
+container" references all overloads where the binding parameter is an instance
+or a collection of the given type.
 
 ## <a name="ConstantExpression" href="#ConstantExpression">14.3 Constant Expression</a>
 

--- a/odata-csdl/14 Vocabulary and Annotation.md
+++ b/odata-csdl/14 Vocabulary and Annotation.md
@@ -580,6 +580,16 @@ qualified name of action followed by parentheses containing the binding paramete
 all overloads of an [Action](#Action)| 
 qualified name of action| 
 <pre>`MySchema.MyAction`</pre>
+bound [Action](#Action) overload via container| 
+Navigation Property via container or Property via container, followed by bound Action overload| 
+<pre>`MySchema.MyEntityContainer/MyEntitySet` 
+<br>` /MyNavigationProperty` 
+<br>` /MySchema.MyAction(Collection(MySchema.MyBindingType))`</pre>
+all bound [Action](#Action) overloads with given binding type via container| 
+Navigation Property via container or Property via container, followed by all overloads of an Action| 
+<pre>`MySchema.MyEntityContainer/MyEntitySet` 
+<br>` /MyNavigationProperty` 
+<br>` /MySchema.MyAction`</pre>
 [Action Import](#ActionImport)| 
 qualified name of entity container followed by a segment containing the action import name| 
 <pre>`MySchema.MyEntityContainer/MyActionImport`</pre>
@@ -614,6 +624,16 @@ qualified name of function followed by parentheses containing the comma-separate
 all overloads of a [Function](#Function)| 
 qualified name of function| 
 <pre>`MySchema.MyFunction`</pre>
+bound [Function](#Function) overload via container| 
+Navigation Property via container or Property via container, followed by bound Function overload| 
+<pre>`MySchema.MyEntityContainer/MyEntitySet` 
+<br>` /MyComplexProperty` 
+<br>` /MySchema.MyFunction(MySchema.MyBindingType)`</pre>
+all bound [Function](#Function) overloads of given binding type via container| 
+Navigation Property via container or Property via container, followed by all overloads of a Function| 
+<pre>`MySchema.MyEntityContainer/MyEntitySet` 
+<br>` /MyComplexProperty` 
+<br>` /MySchema.MyFunction`</pre>
 [Function Import](#FunctionImport)| 
 qualified name of entity container followed by a segment containing the function import name| 
 <pre>`MySchema.MyEntityContainer/MyFunctionImport`
@@ -673,6 +693,15 @@ External targeting is possible for properties and navigation
 properties of singletons or entities in a particular entity set. These
 annotations override annotations on the properties or navigation
 properties targeted via the declaring structured type.
+
+External targeting is also possible for action and function overloads that
+are bound to properties or navigation properties of singletons or entities in
+a particular entity set. These annotations override annotations targeting the
+action or function overloads directly.
+
+Note "all bound Action or Function overloads of given binding type via
+container" references all overloads where the binding parameter is an instance
+or a collection of the given type.
 
 ## ##subsec Constant Expression
 


### PR DESCRIPTION
Shall we also allow schema-bound paths like
```
MySchema.MyEntityType/MyNavigationProperty/MyFunction
```
?