### PR TITLE
Clone with correct line endings on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.html  text eol=lf
+*.md    text eol=lf
+*.pdf   -text

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "odata-specs",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "c8": "^8.0.0",
         "express": "^4",


### PR DESCRIPTION
HTML and Markdown files are cloned with LF line endings
This avoids problems on Windows machines with default git setting `core.autocrlf=true`