### PR TITLE
Init `server.js`

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -15,6 +15,10 @@ liveReloadServer.watch(path.join(__dirname, ".."));
 const connectLivereload = require("connect-livereload");
 const statics = { images: {} };
 
+iterator(function (srcname, name, variant, meta) {
+  new Number(`${__dirname}/../${srcname}`, variant, meta).read();
+});
+
 const app = express()
   .enable("strict routing")
   .use(connectLivereload())


### PR DESCRIPTION
Initialize `server.js` so that it can resolve cross-spec references