### PR TITLE
Corrected link

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -103,4 +103,4 @@ See the source Markdown [here](../odata-data-aggregation-ext/1%20Introduction.md
 
 # OData TC meeting minutes
 
-Minutes of OData TC meetings are created as [discussions](/oasis-tcs/odata-specs/discussions/categories/minutes). A PDF version can be created in the `minutes` folder with the command [`npm run minutes <number of discussion>`](minutes.mjs).
+Minutes of OData TC meetings are created as [discussions](https://github.com/oasis-tcs/odata-specs/discussions/categories/minutes). A PDF version can be created in the `minutes` folder with the command [`npm run minutes <number of discussion>`](minutes.mjs).

--- a/lib/README.md
+++ b/lib/README.md
@@ -103,4 +103,4 @@ See the source Markdown [here](../odata-data-aggregation-ext/1%20Introduction.md
 
 # OData TC meeting minutes
 
-Minutes of OData TC meetings are created as [discussions](../../../../discussions/categories/minutes). A PDF version can be created in the `minutes` folder with the command [`npm run minutes <number of discussion>`](minutes.mjs).
+Minutes of OData TC meetings are created as [discussions](../../../discussions/categories/minutes). A PDF version can be created in the `minutes` folder with the command [`npm run minutes <number of discussion>`](minutes.mjs).

--- a/lib/README.md
+++ b/lib/README.md
@@ -103,4 +103,4 @@ See the source Markdown [here](../odata-data-aggregation-ext/1%20Introduction.md
 
 # OData TC meeting minutes
 
-Minutes of OData TC meetings are created as [discussions](../../../discussions/categories/minutes). A PDF version can be created in the `minutes` folder with the command [`npm run minutes <number of discussion>`](minutes.mjs).
+Minutes of OData TC meetings are created as [discussions](/oasis-tcs/odata-specs/discussions/categories/minutes). A PDF version can be created in the `minutes` folder with the command [`npm run minutes <number of discussion>`](minutes.mjs).


### PR DESCRIPTION
Relative links that work in the `main` branch do not work in a `new/feature` branch whose name contains slashes.