### PR TITLE
Services shouldn't reduce set of default properties

### DIFF
--- a/docs/odata-protocol/odata-protocol.html
+++ b/docs/odata-protocol/odata-protocol.html
@@ -791,11 +791,12 @@ This uses pandoc 3.8.3 from https://github.com/jgm/pandoc/releases/tag/3.8.3.
 <li>Clients should be prepared to receive properties and derived types not previously defined by the service.</li>
 <li>Clients that cache metadata should be prepared to receive references to new schema elements in response payloads, including types, properties, entity sets, singletons, operations and terms, in existing or new namespaces, that may not have been part of the cached metadata.</li>
 <li>Clients should be prepared to receive references to schema elements defined in new metadata documents, including metadata documents not referenced by the original schema.</li>
+<li>Clients should use <code>$select</code> to select required properties, as the service may change the default set of properties returned in the absence of <code>$select</code>.</li>
 </ul>
 <p>Services SHOULD NOT change their data model depending on the authenticated user. If the data model is user or user-group dependent, all changes MUST be <em>safe changes</em> as defined in this section when comparing the full model to the model visible to users with restricted authorizations.</p>
+<h2>Services MAY change the default set of properties returned in the absence of <code>$select</code> but, for backward compatibility, SHOULD NOT reduce the set of properties returned by default.</h2>
 </details>
 </details>
-<hr />
 <details open><summary>
 <h1 id="6-extensibility"><a id="Extensibility" href="#Extensibility">6 Extensibility</a></h1>
 </summary>
@@ -1806,7 +1807,7 @@ http://host/service/$metadata#Customers/$delta</code></pre>
 <pre><code>GET http://host/service/Customers?$select=ID,Addresses/$count($filter=startswith(City,&#39;H&#39;))</code></pre>
 </div>
 <p>If the <code>$select</code> query option is not specified, the service returns the full set of properties or a default set of properties. In either case it MUST include all key properties, expanding navigation properties as necessary to include key properties from related entities <a href="https://docs.oasis-open.org/odata/odata-csdl-json/v4.02/odata-csdl-json-v4.02.html#Key">OData-CSDL, section 6.5</a> irrespective of the system query option <a href="#SystemQueryOptionexpand"><code>$expand</code></a>.</p>
-<p>Services may change the default set of properties returned. This includes returning new properties by default and omitting properties previously returned by default. Clients that rely on specific properties in the response MUST use <code>$select</code> with the required properties or with <code>*</code>.</p>
+<p>Services may change the default set of properties returned. While, for backward compatibility, services SHOULD NOT omit properties previously returned by default, clients that rely on specific properties in the response MUST use <code>$select</code> with the required properties or with <code>*</code>.</p>
 <p>If the service returns less than the full set of properties, either because the client specified a select or because the service returned a subset of properties in the absence of a select, the <a href="#ContextURL">context URL</a> MUST reflect the set of selected properties and projected <a href="#SystemQueryOptionexpand">expanded</a> navigation properties.</p>
 <details open><summary>
 <h5 id="112511-select-options"><a id="SelectOptions" href="#SelectOptions">11.2.5.1.1 Select Options</a></h5>

--- a/docs/odata-protocol/odata-protocol.html
+++ b/docs/odata-protocol/odata-protocol.html
@@ -794,9 +794,10 @@ This uses pandoc 3.8.3 from https://github.com/jgm/pandoc/releases/tag/3.8.3.
 <li>Clients should use <code>$select</code> to select required properties, as the service may change the default set of properties returned in the absence of <code>$select</code>.</li>
 </ul>
 <p>Services SHOULD NOT change their data model depending on the authenticated user. If the data model is user or user-group dependent, all changes MUST be <em>safe changes</em> as defined in this section when comparing the full model to the model visible to users with restricted authorizations.</p>
-<h2>Services MAY change the default set of properties returned in the absence of <code>$select</code> but, for backward compatibility, SHOULD NOT reduce the set of properties returned by default.</h2>
+<p>Services MAY change the default set of properties returned in the absence of <code>$select</code> but, for backward compatibility, SHOULD NOT reduce the set of properties returned by default.</p>
 </details>
 </details>
+<hr />
 <details open><summary>
 <h1 id="6-extensibility"><a id="Extensibility" href="#Extensibility">6 Extensibility</a></h1>
 </summary>

--- a/docs/odata-protocol/odata-protocol.md
+++ b/docs/odata-protocol/odata-protocol.md
@@ -763,6 +763,9 @@ part of the cached metadata.
 - Clients should be prepared to receive references to schema
 elements defined in new metadata documents, including metadata
 documents not referenced by the original schema.
+- Clients should use `$select` to select required properties, as the
+service may change the default set of properties returned in the
+absence of `$select`.
 
 Services SHOULD NOT change their data model depending on the
 authenticated user. If the data model is user or user-group dependent,
@@ -770,6 +773,9 @@ all changes MUST be *safe changes* as defined in this section when
 comparing the full model to the model visible to users with restricted
 authorizations.
 
+Services MAY change the default set of properties returned in the
+absence of `$select` but, for backward compatibility, SHOULD NOT
+reduce the set of properties returned by default.
 -------
 
 # <a id="Extensibility" href="#Extensibility">6 Extensibility</a>
@@ -3013,11 +3019,10 @@ it MUST include all key properties, expanding navigation properties as necessary
 to include key properties from related entities
 [OData-CSDL, section 6.5](https://docs.oasis-open.org/odata/odata-csdl-json/v4.02/odata-csdl-json-v4.02.html#Key) irrespective of the system query option [`$expand`](#SystemQueryOptionexpand).
 
-Services may change the default set of properties returned. This
-includes returning new properties by default and omitting properties
-previously returned by default. Clients that rely on
-specific properties in the response MUST use
-`$select` with the required properties or with `*`.
+Services may change the default set of properties returned.
+While, for backward compatibility, services SHOULD NOT omit properties
+previously returned by default, clients that rely on specific properties
+in the response MUST use `$select` with the required properties or with `*`.
 
 If the service returns less than the full set
 of properties, either because the client specified a select or because

--- a/docs/odata-protocol/odata-protocol.md
+++ b/docs/odata-protocol/odata-protocol.md
@@ -776,6 +776,7 @@ authorizations.
 Services MAY change the default set of properties returned in the
 absence of `$select` but, for backward compatibility, SHOULD NOT
 reduce the set of properties returned by default.
+
 -------
 
 # <a id="Extensibility" href="#Extensibility">6 Extensibility</a>

--- a/odata-protocol/1 Introduction.md
+++ b/odata-protocol/1 Introduction.md
@@ -465,6 +465,7 @@ authorizations.
 Services MAY change the default set of properties returned in the
 absence of `$select` but, for backward compatibility, SHOULD NOT
 reduce the set of properties returned by default.
+
 -------
 
 # ##sec Extensibility

--- a/odata-protocol/1 Introduction.md
+++ b/odata-protocol/1 Introduction.md
@@ -452,6 +452,9 @@ part of the cached metadata.
 - Clients should be prepared to receive references to schema
 elements defined in new metadata documents, including metadata
 documents not referenced by the original schema.
+- Clients should use `$select` to select required properties, as the
+service may change the default set of properties returned in the
+absence of `$select`.
 
 Services SHOULD NOT change their data model depending on the
 authenticated user. If the data model is user or user-group dependent,
@@ -459,6 +462,9 @@ all changes MUST be *safe changes* as defined in this section when
 comparing the full model to the model visible to users with restricted
 authorizations.
 
+Services MAY change the default set of properties returned in the
+absence of `$select` but, for backward compatibility, SHOULD NOT
+reduce the set of properties returned by default.
 -------
 
 # ##sec Extensibility

--- a/odata-protocol/11 Data Service Requests.md
+++ b/odata-protocol/11 Data Service Requests.md
@@ -409,11 +409,10 @@ it MUST include all key properties, expanding navigation properties as necessary
 to include key properties from related entities
 [#OData-CSDL#Key] irrespective of the system query option [`$expand`](#SystemQueryOptionexpand).
 
-Services may change the default set of properties returned. This
-includes returning new properties by default and omitting properties
-previously returned by default. Clients that rely on
-specific properties in the response MUST use
-`$select` with the required properties or with `*`.
+Services may change the default set of properties returned.
+While, for backward compatibility, services SHOULD NOT omit properties
+previously returned by default, clients that rely on specific properties
+in the response MUST use `$select` with the required properties or with `*`.
 
 If the service returns less than the full set
 of properties, either because the client specified a select or because


### PR DESCRIPTION
clients should still use $select.

Fixes #2206