### PR TITLE
Add conformance for $select=$key

### DIFF
--- a/docs/odata-protocol/odata-protocol.html
+++ b/docs/odata-protocol/odata-protocol.html
@@ -3860,7 +3860,7 @@ Content-Length: ###
 <ol type="1">
 <li>MUST conform to the <a href="#OData402MinimalConformanceLevel">OData 4.02 Minimal Conformance Level</a></li>
 <li>MUST conform to the <a href="#OData401IntermediateConformanceLevel">OData 4.01 Intermediate Conformance Level</a></li>
-<li>MUST support <code>$select</code> with an empty select list</li>
+<li>MUST support <code>$key</code> in <code>$select</code></li>
 <li>MUST, if they support optimistic concurrency, return etag values for added/changed entities in a delta payload</li>
 <li>MUST support Key-As-Segment URL convention in addition to canonical URL conventions</li>
 <li>SHOULD support Passing Query Options in the Request Body (See Url Conventions)

--- a/docs/odata-protocol/odata-protocol.html
+++ b/docs/odata-protocol/odata-protocol.html
@@ -3922,7 +3922,8 @@ Content-Length: ###
 <li>MUST be prepared to receive any valid 4.02 response according to the requested format</li>
 <li>SHOULD use capabilities (see <a href="#ODataVocCap">OData-VocCap</a>) to determine if a 4.02 feature is supported but MAY attempt syntax and be prepared to handle <code>400 Bad Request</code> or <a href="#ResponseCode501NotImplemented"><code>501 Not Implemented</code></a></li>
 <li>SHOULD use Context URL to interpret payloads, rather than inferring from the request</li>
-<li>SHOULD NOT specify an empty <code>$select</code> or <code>$expand</code> list to a 4.01 or earlier service</li>
+<li>SHOULD NOT specify an empty <code>$expand</code> list to a 4.01 or earlier service</li>
+<li>SHOULD NOT specify <code>$key</code> in a <code>$select</code> list to a 4.01 or earlier service</li>
 </ol>
 </details>
 </details>

--- a/docs/odata-protocol/odata-protocol.md
+++ b/docs/odata-protocol/odata-protocol.md
@@ -7387,7 +7387,8 @@ the requested format
 determine if a 4.02 feature is supported but MAY attempt syntax and be
 prepared to handle `400 Bad Request` or [`501 Not Implemented`](#ResponseCode501NotImplemented)
 25. SHOULD use Context URL to interpret payloads, rather than inferring from the request
-26. SHOULD NOT specify an empty `$select` or `$expand` list to a 4.01 or earlier service
+26. SHOULD NOT specify an empty `$expand` list to a 4.01 or earlier service
+27. SHOULD NOT specify `$key` in a `$select` list to a 4.01 or earlier service
 
 
 -------

--- a/docs/odata-protocol/odata-protocol.md
+++ b/docs/odata-protocol/odata-protocol.md
@@ -7298,7 +7298,7 @@ service:
 1. MUST conform to the [OData 4.02 Minimal Conformance Level](#OData402MinimalConformanceLevel)
 2. MUST conform to the [OData 4.01 Intermediate Conformance
 Level](#OData401IntermediateConformanceLevel)
-3. MUST support `$select` with an empty select list
+3. MUST support `$key` in `$select`
 4. MUST, if they support optimistic concurrency, return etag values for added/changed entities in a delta payload
 5. MUST support Key-As-Segment URL convention in addition to canonical URL conventions
 6. SHOULD support Passing Query Options in the Request Body (See Url Conventions)

--- a/odata-protocol/12 Conformance.md
+++ b/odata-protocol/12 Conformance.md
@@ -391,7 +391,7 @@ service:
 1. MUST conform to the [OData 4.02 Minimal Conformance Level](#OData402MinimalConformanceLevel)
 2. MUST conform to the [OData 4.01 Intermediate Conformance
 Level](#OData401IntermediateConformanceLevel)
-3. MUST support `$select` with an empty select list
+3. MUST support `$key` in `$select`
 4. MUST, if they support optimistic concurrency, return etag values for added/changed entities in a delta payload
 5. MUST support Key-As-Segment URL convention in addition to canonical URL conventions
 6. SHOULD support Passing Query Options in the Request Body (See Url Conventions)

--- a/odata-protocol/12 Conformance.md
+++ b/odata-protocol/12 Conformance.md
@@ -480,4 +480,5 @@ the requested format
 determine if a 4.02 feature is supported but MAY attempt syntax and be
 prepared to handle `400 Bad Request` or [`501 Not Implemented`](#ResponseCode501NotImplemented)
 25. SHOULD use Context URL to interpret payloads, rather than inferring from the request
-26. SHOULD NOT specify an empty `$select` or `$expand` list to a 4.01 or earlier service
+26. SHOULD NOT specify an empty `$expand` list to a 4.01 or earlier service
+27. SHOULD NOT specify `$key` in a `$select` list to a 4.01 or earlier service


### PR DESCRIPTION
Add conformance for $key in $select.
Remove conformance for empty $select.

Fixes https://github.com/oasis-tcs/odata-specs/issues/2257