### PR TITLE
Speed up livereload

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -2,19 +2,18 @@ const express = require("express");
 const Number = require("./number");
 const pandoc = require("./pandoc");
 const { execSync } = require("child_process");
-const path = require("path");
 const fs = require("fs");
 const yaml = require("js-yaml");
 const iterator = require("./iterator");
 
 const livereload = require("livereload");
 const liveReloadServer = livereload.createServer({ extraExts: ["md"] });
-liveReloadServer.watch(path.join(__dirname, ".."));
 
 const connectLivereload = require("connect-livereload");
 const statics = { images: {} };
 
 iterator(function (srcname, name, variant, meta) {
+  liveReloadServer.watch(`${__dirname}/../${srcname}`);
   new Number(`${__dirname}/../${srcname}`, variant, meta).read();
 });
 


### PR DESCRIPTION
The livereload library used in `lib/server.js` took extremely long to start up, apparently because it watched everything in `node_modules`.